### PR TITLE
Fix gitlab.com agent duplication by sanitizing usernames

### DIFF
--- a/gitlab2prov/__init__.py
+++ b/gitlab2prov/__init__.py
@@ -40,6 +40,7 @@ class Gitlab2Prov:
         graphs = self.run_pipelines(url)
         graph = self.unite_graphs(graphs)
         graph = self.postprocess(graph, url)
+        graph = self.unite_agents(graph, alias_map={})
         return graph
 
     def unite_graphs(self, graphs):

--- a/gitlab2prov/__init__.py
+++ b/gitlab2prov/__init__.py
@@ -65,7 +65,7 @@ class Gitlab2Prov:
         """Prepend project identifier to identifiers of activities and entities.
         Add project identifier to node attributes of activities and entities."""
         records = list(graph.get_records(ProvAgent))
-        id_mapping = {agent.identifier: agent.identifier for agent in records}
+        id_map = {agent.identifier: agent.identifier for agent in records}
         project = url_encoded_path(url).replace("%2F", "/")
 
         for record in graph.get_records((ProvActivity, ProvEntity)):
@@ -75,7 +75,7 @@ class Gitlab2Prov:
             identifier = record.identifier
             namespace, localpart = identifier.namespace, identifier.localpart
             unique_id = QualifiedName(namespace, q_name(f"{project}-{localpart}"))
-            id_mapping[identifier] = unique_id
+            id_map[identifier] = unique_id
 
             if isinstance(record, ProvEntity):
                 records.append(ProvEntity(record.bundle, unique_id, attributes))
@@ -84,16 +84,16 @@ class Gitlab2Prov:
 
         records.extend(graph.get_records(ProvRelation))
         graph = ProvDocument(records)
-        graph = self.update_relations(graph, id_mapping)
+        graph = self.update_relations(graph, id_map)
         return graph
 
-    def update_relations(self, graph, id_mapping):
+    def update_relations(self, graph, id_map):
         """Update start and enpoints of relations according to node id mapping."""
         records = list(graph.get_records(ProvElement))
         for relation in graph.get_records(ProvRelation):
             (s_type, s), (t_type, t) = relation.formal_attributes[:2]
 
-            attributes = [(s_type, id_mapping.get(s, s)), (t_type, id_mapping.get(t, t))]
+            attributes = [(s_type, id_map.get(s, s)), (t_type, id_map.get(t, t))]
             attributes.extend(relation.formal_attributes[2:])
             attributes.extend(relation.extra_attributes)
 

--- a/gitlab2prov/procs/meta.py
+++ b/gitlab2prov/procs/meta.py
@@ -110,14 +110,14 @@ class Creator(IntermediateRepresentation):
 
     @classmethod
     def from_issue(cls, issue: Issue) -> Creator:
-        name = issue["author"]["name"]
+        name = issue["author"]["name"].strip()
         attributes = {PROV_ROLE: "creator", "name": name}
         return cls(id_section=name, attributes=attributes)
 
     @classmethod
     def from_merge_request(cls, merge_request: MergeRequest) -> Creator:
         """Create a creator meta agent form a merge request API resource."""
-        name = merge_request["author"]["name"]
+        name = merge_request["author"]["name"].strip()
         attributes = {PROV_ROLE: "creator", "name": name}
         return cls(id_section=name, attributes=attributes)
 
@@ -132,16 +132,18 @@ class Author(IntermediateRepresentation):
     @classmethod
     def from_commit(cls, commit: Commit) -> Author:
         """Create an author meta agent from a commit API resource."""
-        attr_keys = ["author_name", "author_email"]
-        attributes = {key.split("_")[1]: value for key, value in commit.items() if key in attr_keys}
+        attributes = {}
+        attributes["name"] = commit["author_name"].strip()
+        attributes["email"] = commit["author_email"]
         attributes.update({PROV_ROLE: "author"})
-        return cls(id_section=commit["author_name"], attributes=attributes)
+        return cls(id_section=attributes["name"], attributes=attributes)
 
     @classmethod
     def from_release(cls, release):
         attributes = {k: v for k, v in release["author"].items() if v}
+        attributes["name"] = attributes["name"].strip()
         attributes[PROV_ROLE] = "author"
-        return cls(id_section=release["author"]["name"], attributes=attributes)
+        return cls(id_section=attributes["name"], attributes=attributes)
 
     @classmethod
     def from_tag(cls, tag):
@@ -158,10 +160,11 @@ class Committer(IntermediateRepresentation):
     @classmethod
     def from_commit(cls, commit: Commit) -> Committer:
         """Create an author meta agent from a commit API resource."""
-        attr_keys = ["committer_name", "committer_email"]
-        attributes = {key.split("_")[1]: value for key, value in commit.items() if key in attr_keys}
+        attributes = {}
+        attributes["name"] = commit["committer_name"].strip()
+        attributes["email"] = commit["committer_email"]
         attributes.update({PROV_ROLE: "committer"})
-        return cls(id_section=commit["committer_name"], attributes=attributes)
+        return cls(id_section=attributes["name"], attributes=attributes)
 
 
 class Initiator(IntermediateRepresentation):
@@ -175,20 +178,20 @@ class Initiator(IntermediateRepresentation):
     @classmethod
     def from_note(cls, note: Note) -> Initiator:
         """Create an initiator meta agent from a note API resource."""
-        attributes = {PROV_ROLE: "initiator", "name": note["author"]["name"]}
-        return cls(id_section=note["author"]["name"], attributes=attributes)
+        attributes = {PROV_ROLE: "initiator", "name": note["author"]["name"].strip()}
+        return cls(id_section=attributes["name"], attributes=attributes)
 
     @classmethod
     def from_label(cls, label: Label) -> Initiator:
         """Create an initiator meta agent from a label event API resource."""
-        attributes = {PROV_ROLE: "initiator", "name": label["user"]["name"]}
-        return cls(id_section=label["user"]["name"], attributes=attributes)
+        attributes = {PROV_ROLE: "initiator", "name": label["user"]["name"].strip()}
+        return cls(id_section=attributes["name"], attributes=attributes)
 
     @classmethod
     def from_award(cls, award: Award) -> Initiator:
         """Create an initiator meta agent from an award API resource."""
-        attributes = {PROV_ROLE: "initiator", "name": award["user"]["name"]}
-        return cls(id_section=award["user"]["name"], attributes=attributes)
+        attributes = {PROV_ROLE: "initiator", "name": award["user"]["name"].strip()}
+        return cls(id_section=attributes["name"], attributes=attributes)
 
 
 class MetaEvent(IntermediateRepresentation):


### PR DESCRIPTION
Fixes #45.

Changes proposed in this pull request:
- Remove trailing whitespace from username mentions
- Support multi-valued attributes for ProvAgents